### PR TITLE
Fixes typo on sshkey delete command

### DIFF
--- a/bitbucket/ssh.py
+++ b/bitbucket/ssh.py
@@ -182,7 +182,7 @@ class Sshkeydelete(Command):
 
         url = ("https://bitbucket.org/api/1.0/"
                "users/{a.account}/"
-               "ssh-keys/{a.key_id}").forma(a=parsed_args)
+               "ssh-keys/{a.key_id}").format(a=parsed_args)
         user, passwd = read_creds()
         r = requests.delete(url, auth=(user, passwd))
         if r.status_code == 204:


### PR DESCRIPTION
Modifies:
- bitbucket/ssh.py
Edits call from forma to format in order to fix AtributeError due to typo.
Fixes: https://github.com/yspanchal/bitbucketcli/issues/20